### PR TITLE
Fix track sort

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -121,7 +121,7 @@ def generate_rss(request, books):
             track_list.append(track)
         else:
             # we have populated and unique track values, use those
-            key = lambda x: books[book]['files'][x]['track']
+            key = lambda x: int(books[book]['files'][x]['track'])
 
     # populate XML attribute values required by Apple podcasts
     for idx, f in enumerate(sorted(books[book]['files'], key=key)):


### PR DESCRIPTION
Track sort was operating on strings like "1", "2", "10", "11", etc, which sorted to ["1", "10", "11", "2"]
Convert to integers when sorting to fix this.