### PR TITLE
Static generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 __pycache__
 cache
 sandbox
+static
 app.cfg
 uwsgi.ini

--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ A screenshot of the web interface is [available here](screenshots/web.png).
     ./uwsgi.sh
     ```
 
+## Static generation
+
+In addition to running as a server, Roka can also generate a static index and
+set of RSS feeds that can be deployed to static hosting. This mode does not
+support a username and password.
+
+1. Run roka.py with `--generate <output_directory> --base_url <url>` parameters
+   where `<output_directory>` is a directory to place the generated site and
+   `<url>` is the base url where the static site will be uploaded to.
+
+   ```bash
+   ./roka.py --generate ./static --base_url "https://example.com/"
+   ```
+
+2. Upload the static site to any static web hosting. Make sure it is accessible
+   at the URL previously passed in as `--base_url`
+
 ## Design decisions
 
 1. Directories contained within config:ROOT_PATH are marked as audiobooks if and

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ support a username and password.
    uploaded.
 
 2. Run roka.py with the `--generate <output_directory>` parameter, where
-   `<output_directory>` is an output directory to place the generated site.
+   `<output_directory>` is an output directory to place the generated site. All
+   audiobook files will be copied to this location.
 
    ```bash
    ./roka.py --generate ./static

--- a/README.md
+++ b/README.md
@@ -33,16 +33,18 @@ In addition to running as a server, Roka can also generate a static index and
 set of RSS feeds that can be deployed to static hosting. This mode does not
 support a username and password.
 
-1. Run roka.py with `--generate <output_directory> --base_url <url>` parameters
-   where `<output_directory>` is a directory to place the generated site and
-   `<url>` is the base url where the static site will be uploaded to.
+1. Set `BASE_URL` in app.cfg to the base url where the static site will be
+   uploaded.
+
+2. Run roka.py with the `--generate <output_directory>` parameter, where
+   `<output_directory>` is an output directory to place the generated site.
 
    ```bash
-   ./roka.py --generate ./static --base_url "https://example.com/"
+   ./roka.py --generate ./static
    ```
 
-2. Upload the static site to any static web hosting. Make sure it is accessible
-   at the URL previously passed in as `--base_url`
+3. Upload the static site to any static web hosting. Make sure it is accessible
+   at the URL set as `BASE_URL`
 
 ## Design decisions
 
@@ -68,3 +70,8 @@ support a username and password.
 
 4. No rebuild endpoint exists; cache-affecting routines are run externally by
    calling roka.py directly
+
+5. Configuration can either be placed in a file named `app.cfg`, or it can be
+   overridden on the terminal by passing a JSON string as the `--config`
+   parameter. I.E. `./roka.py --generate ./static --config '{"ROOT_PATH":
+   "/path/to/audiobooks", "BASE_URL": "https://example.com/"}'`

--- a/app.cfg.example
+++ b/app.cfg.example
@@ -1,3 +1,5 @@
 ROOT_PATH = '/path/to/audiobooks'
+# BASE_URL is only used for static generation
+BASE_URL = 'https://example.com/'
 USERNAME = 'username'
 PASSWORD = 'password'

--- a/lib/books.py
+++ b/lib/books.py
@@ -15,7 +15,8 @@ JSON_PATH = os.path.join(CACHE_PATH, 'audiobooks.json')
 
 # use Flask's config parser, configparser would be hacky
 APP = Flask(__name__)
-APP.config.from_pyfile(os.path.join(ABS_PATH, '../', 'app.cfg'))
+if os.path.exists(os.path.join(ABS_PATH, '../', 'app.cfg')):
+    APP.config.from_pyfile(os.path.join(ABS_PATH, '../', 'app.cfg'))
 
 class Books:
     def __init__(self):

--- a/lib/books.py
+++ b/lib/books.py
@@ -13,11 +13,6 @@ ABS_PATH = os.path.dirname(os.path.abspath(__file__))
 CACHE_PATH = os.path.join(ABS_PATH, '../', 'cache')
 JSON_PATH = os.path.join(CACHE_PATH, 'audiobooks.json')
 
-# use Flask's config parser, configparser would be hacky
-APP = Flask(__name__)
-if os.path.exists(os.path.join(ABS_PATH, '../', 'app.cfg')):
-    APP.config.from_pyfile(os.path.join(ABS_PATH, '../', 'app.cfg'))
-
 class Books:
     def __init__(self):
         '''
@@ -95,7 +90,7 @@ class Books:
                 (existing content is not re-hashed)
         '''
         ex = self._get_path_hash_dict()
-        dirs = self._get_dirs(audiobook_path or APP.config['ROOT_PATH'])
+        dirs = self._get_dirs(audiobook_path)
 
         books = dict()
         for path in dirs:

--- a/lib/books.py
+++ b/lib/books.py
@@ -86,7 +86,7 @@ class Books:
         now = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
         print('%s %s' % (now, msg))
 
-    def scan_books(self):
+    def scan_books(self, audiobook_path=None):
         '''
         Discover audiobooks under :root_path: and populate books object
 
@@ -94,7 +94,7 @@ class Books:
                 (existing content is not re-hashed)
         '''
         ex = self._get_path_hash_dict()
-        dirs = self._get_dirs(APP.config['ROOT_PATH'])
+        dirs = self._get_dirs(audiobook_path or APP.config['ROOT_PATH'])
 
         books = dict()
         for path in dirs:
@@ -145,7 +145,7 @@ class Books:
 
             # previous conditions met, we've found at least one track
             is_book = True
-            self._log(f)
+            self._log(os.path.join(path, f))
 
             # hash track (used as a key) and update folder hash
             file_hash = hashlib.md5()

--- a/lib/util.py
+++ b/lib/util.py
@@ -78,9 +78,7 @@ def escape(s):
 
     return s
 
-def generate_rss(request, books):
-    book = request.args.get('a') # audiobook hash
-
+def generate_rss(base_url, book, books, static=False):
     # we only make use of the itunes ns, others provided for posterity
     namespaces = {
         'itunes':'http://www.itunes.com/dtds/podcast-1.0.dtd',
@@ -156,8 +154,9 @@ def generate_rss(request, books):
         pub_format = '%a, %d %b %Y %H:%M:%S %z'
         pub_date.text = (date(2000, 12, 31) - timedelta(days=idx)).strftime(
                 pub_format)
+        url_format = '{}{}/{}.mp3' if static else '{}?a={}&f={}'
         enc_attr = {
-            'url': '{}?a={}&f={}'.format(request.base_url, book, f),
+            'url': url_format.format(base_url, book, f),
             'length': str(books[book]['files'][f]['size_bytes']),
             'type': 'audio/mpeg'
         }

--- a/lib/util.py
+++ b/lib/util.py
@@ -119,7 +119,7 @@ def generate_rss(base_url, book, books, static=False):
             track_list.append(track)
         else:
             # we have populated and unique track values, use those
-            key = lambda x: books[book]['files'][x]['track']
+            key = lambda x: int(books[book]['files'][x]['track'])
 
     # populate XML attribute values required by Apple podcasts
     for idx, f in enumerate(sorted(books[book]['files'], key=key)):

--- a/roka.py
+++ b/roka.py
@@ -97,16 +97,10 @@ if __name__ == '__main__':
     parser.add_argument('--generate', dest='static_path', type=str, action='store',
                         help='Output directory to generate static files',
                         required=False)
-    parser.add_argument('--base_url', dest='base_url', type=str, action='store',
-                        help='Base URL to use in static files',
-                        required=False)
     parser.add_argument('--config', dest='config', type=str, action='store',
                         help='Json configuration instead of app.cfg',
                         required=False)
     args = parser.parse_args()
-
-    if args.static_path and not args.base_url or args.base_url and not args.static_path:
-        parser.error('--generate and --base_url must be included together')
 
     if args.config:
         class objectview(object):
@@ -124,6 +118,6 @@ if __name__ == '__main__':
         books.scan_books(root_path)
         books.write_cache()
     elif args.static_path:
-        generate(args.static_path, args.base_url, root_path)
+        generate(args.static_path, app.config['BASE_URL'], root_path)
     else:
         app.run(host='127.0.0.1', port='8085', threaded=True)

--- a/roka.py
+++ b/roka.py
@@ -12,9 +12,6 @@ app = Flask(__name__)
 app.config.from_pyfile(os.path.join(abs_path, 'app.cfg'))
 cache_path = os.path.join(abs_path, 'cache')
 json_path = os.path.join(cache_path, 'audiobooks.json')
-static_path = os.path.join(abs_path, 'static')
-static_index_path = os.path.join(static_path, 'index.html')
-base_url = "blah.com/"
 
 @app.route('/')
 def list_books():
@@ -55,6 +52,7 @@ def list_books():
 
         return render_template('index.html', books=books)
 
+# TODO does this really need to be here?
 def my_render_template(
     app, template_name_or_list, **context
 ) -> str:
@@ -74,9 +72,12 @@ def my_render_template(
         app,
     )
 
-def generate():
+def generate(static_path, base_url):
+    static_index_path = os.path.join(static_path, 'index.html')
+
     books = Books()
     books.scan_books()
+    # TODO avoid writing and reading cache
     books.write_cache()
     books = read_cache(json_path)
     index = my_render_template(app, 'index.html', books=books, static=True)
@@ -100,7 +101,6 @@ def generate():
         for f_key, file in book['files'].items():
             f_path = file['path']
             copy_path = os.path.join(book_dir, f_key + '.mp3')
-            # print("File: {} {} {}".format(f_key, f_path, copy_path))
             shutil.copyfile(f_path, copy_path)
 
 if __name__ == '__main__':
@@ -109,16 +109,22 @@ if __name__ == '__main__':
     parser.add_argument('--scan', dest='scan', action='store_true',
                         help='scan audiobooks directory for new books',
                         required=False)
-    parser.add_argument('--generate', dest='generate', action='store_true',
-                        help='',
+    parser.add_argument('--generate', dest='static_path', type=str, action='store',
+                        help='Output directory to generate static files',
+                        required=False)
+    parser.add_argument('--base_url', dest='base_url', type=str, action='store',
+                        help='Base URL to use in static files',
                         required=False)
     args = parser.parse_args()
+
+    if args.static_path and not args.base_url or args.base_url and not args.static_path:
+        parser.error("--generate and --base_url must both be included")
 
     if args.scan:
         books = Books()
         books.scan_books()
         books.write_cache()
-    elif args.generate:
-        generate()
+    elif args.static_path:
+        generate(args.static_path, args.base_url)
     else:
         app.run(host='127.0.0.1', port='8085', threaded=True)

--- a/roka.py
+++ b/roka.py
@@ -9,7 +9,8 @@ from lib.util import check_auth, escape, generate_rss, read_cache
 
 abs_path = os.path.dirname(os.path.abspath(__file__))
 app = Flask(__name__)
-app.config.from_pyfile(os.path.join(abs_path, 'app.cfg'))
+if os.path.exists(os.path.join(abs_path, 'app.cfg')):
+    app.config.from_pyfile(os.path.join(abs_path, 'app.cfg'))
 cache_path = os.path.join(abs_path, 'cache')
 json_path = os.path.join(cache_path, 'audiobooks.json')
 

--- a/roka.py
+++ b/roka.py
@@ -11,6 +11,10 @@ from lib.util import check_auth, escape, generate_rss, read_cache
 
 abs_path = os.path.dirname(os.path.abspath(__file__))
 app = Flask(__name__)
+config_path = os.path.join(abs_path, 'app.cfg')
+config_exists = os.path.exists(config_path)
+if config_exists or __name__.startswith('uwsgi'):
+    app.config.from_pyfile(config_path)
 cache_path = os.path.join(abs_path, 'cache')
 json_path = os.path.join(cache_path, 'audiobooks.json')
 
@@ -108,9 +112,10 @@ if __name__ == '__main__':
             def __init__(self, d):
                 self.__dict__ = d
         config = objectview(json.loads(args.config))
+        # override app.cfg
         app.config.from_object(config)
-    else:
-        app.config.from_pyfile(os.path.join(abs_path, 'app.cfg'))
+    elif not config_exists:
+        raise Exception(f"Config file '{config_path}' doesn't exist")
 
     root_path = os.path.expanduser(app.config['ROOT_PATH'])
 

--- a/roka.py
+++ b/roka.py
@@ -121,7 +121,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.static_path and not args.base_url or args.base_url and not args.static_path:
-        parser.error("--generate and --base_url must both be included")
+        parser.error('--generate and --base_url must be included together')
 
     if args.scan:
         books = Books()

--- a/roka.py
+++ b/roka.py
@@ -72,11 +72,11 @@ def my_render_template(
         app,
     )
 
-def generate(static_path, base_url):
+def generate(static_path, base_url, audiobook_dirs):
     static_index_path = os.path.join(static_path, 'index.html')
 
     books = Books()
-    books.scan_books()
+    books.scan_books(audiobook_dirs)
     # TODO avoid writing and reading cache
     books.write_cache()
     books = read_cache(json_path)
@@ -115,6 +115,9 @@ if __name__ == '__main__':
     parser.add_argument('--base_url', dest='base_url', type=str, action='store',
                         help='Base URL to use in static files',
                         required=False)
+    parser.add_argument('--scan_dir', dest='scan_dir', type=str, action='store',
+                        help='Directory to scan for audiobooks',
+                        required=False)
     args = parser.parse_args()
 
     if args.static_path and not args.base_url or args.base_url and not args.static_path:
@@ -122,9 +125,9 @@ if __name__ == '__main__':
 
     if args.scan:
         books = Books()
-        books.scan_books()
+        books.scan_books(args.scan_dir)
         books.write_cache()
     elif args.static_path:
-        generate(args.static_path, args.base_url)
+        generate(args.static_path, args.base_url, args.scan_dir)
     else:
         app.run(host='127.0.0.1', port='8085', threaded=True)

--- a/roka.py
+++ b/roka.py
@@ -2,7 +2,7 @@
 
 import argparse
 import os
-from flask import Flask, request, Response, render_template, send_file
+from flask import Flask, request, Response, render_template, send_file, templating
 from lib.books import Books
 from lib.util import check_auth, escape, generate_rss, read_cache
 
@@ -11,6 +11,9 @@ app = Flask(__name__)
 app.config.from_pyfile(os.path.join(abs_path, 'app.cfg'))
 cache_path = os.path.join(abs_path, 'cache')
 json_path = os.path.join(cache_path, 'audiobooks.json')
+static_path = os.path.join(abs_path, 'static')
+static_index_path = os.path.join(static_path, 'index.html')
+base_url = "blah.com/"
 
 @app.route('/')
 def list_books():
@@ -40,7 +43,7 @@ def list_books():
         if not books.get(a):
             return 'book not found', 404
 
-        rss = generate_rss(request, books)
+        rss = generate_rss(request.base_url, a, books)
         return Response(rss, mimetype='text/xml')
 
     else:
@@ -51,11 +54,51 @@ def list_books():
 
         return render_template('index.html', books=books)
 
+def my_render_template(
+    app, template_name_or_list, **context
+) -> str:
+    """Renders a template from the template folder with the given
+    context.
+
+    :param template_name_or_list: the name of the template to be
+                                  rendered, or an iterable with template names
+                                  the first one existing will be rendered
+    :param context: the variables that should be available in the
+                    context of the template.
+    """
+    app.update_template_context(context)
+    return templating._render(
+        app.jinja_env.get_or_select_template(template_name_or_list),
+        context,
+        app,
+    )
+
+def generate():
+    books = Books()
+    books.scan_books()
+    books.write_cache()
+    books = read_cache(json_path)
+    index = my_render_template(app, 'index.html', books=books, static=True)
+
+    indexfile = open(static_index_path, 'w')
+    indexfile.write(index)
+    indexfile.close()
+
+    for key in books.keys():
+        rss = generate_rss(base_url, key, books, static=True)
+        rss_path = os.path.join(static_path, key + '.xml')
+        rssfile = open(rss_path, 'w')
+        rssfile.write(rss.decode('utf-8'))
+        rssfile.close()
+
 if __name__ == '__main__':
     desc = 'roka: listen to audiobooks with podcast apps via RSS'
     parser = argparse.ArgumentParser(description=desc)
     parser.add_argument('--scan', dest='scan', action='store_true',
                         help='scan audiobooks directory for new books',
+                        required=False)
+    parser.add_argument('--generate', dest='generate', action='store_true',
+                        help='',
                         required=False)
     args = parser.parse_args()
 
@@ -63,5 +106,7 @@ if __name__ == '__main__':
         books = Books()
         books.scan_books()
         books.write_cache()
+    elif args.generate:
+        generate()
     else:
         app.run(host='127.0.0.1', port='8085', threaded=True)

--- a/roka.py
+++ b/roka.py
@@ -114,7 +114,7 @@ if __name__ == '__main__':
                 self.__dict__ = d
         config = objectview(json.loads(args.config))
         app.config.from_object(config)
-    elif os.path.exists(os.path.join(abs_path, 'app.cfg')):
+    else:
         app.config.from_pyfile(os.path.join(abs_path, 'app.cfg'))
 
     root_path = os.path.expanduser(app.config['ROOT_PATH'])

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,7 +35,7 @@
         </tr>
         {% for b, v in books.items() %}
         <tr>
-            <td><a href="?a={{ b }}">{{ v['title']|escape }}</a></td>
+            <td><a href="{{'?a=' if not static else '/'}}{{ b }}{{'.xml' if static}}">{{ v['title']|escape }}</a></td>
             <td>{{ v['path']|escape }}</td>
             <td>{{ v['files']|length }}</td>
             <td>{{ v['duration_str'] }}</td>


### PR DESCRIPTION
These changes allow for generating a static version of Roka's output. Then it can be uploaded to simpler static hosting. This is done with the new `--generate` parameter, and the original functionality still behaves the same.

I also added the ability to override config with a `--config` terminal parameter.